### PR TITLE
add barcode count to Barcode Recognizer Demo

### DIFF
--- a/AISuite_Demos/AIDataCaptureDemo/app/src/main/java/com/zebra/aidatacapturedemo/data/AIDataCaptureDemoUiState.kt
+++ b/AISuite_Demos/AIDataCaptureDemo/app/src/main/java/com/zebra/aidatacapturedemo/data/AIDataCaptureDemoUiState.kt
@@ -145,6 +145,7 @@ data class AIDataCaptureDemoUiState(
     var zoomLevel: Float = 1.0f,
     val appBarTitle: String = "",
     val toastMessage: String? = null,
+    val barcodeCountMap: MutableMap<String, Int> = mutableMapOf<String, Int>(),
 
     // Settings
     var barcodeSettings : BarcodeSettings = FileUtils.loadBarcodeSettings(),

--- a/AISuite_Demos/AIDataCaptureDemo/app/src/main/java/com/zebra/aidatacapturedemo/ui/view/CameraPreviewScreen.kt
+++ b/AISuite_Demos/AIDataCaptureDemo/app/src/main/java/com/zebra/aidatacapturedemo/ui/view/CameraPreviewScreen.kt
@@ -438,8 +438,23 @@ fun DrawBarcodeResult(
                 text = barcodeData.text,
                 selectedDemo = UsecaseState.Barcode.value
             )
+
+            val value = barcodeData.text
+            val count = uiState.barcodeCountMap.get(value) ?: 0
+            uiState.barcodeCountMap.put(value, count+1)
         }
     }
+
+    val list = uiState.barcodeCountMap.map { (key, value) -> "$key($value)" }
+    val result = list.joinToString(separator = "\n")
+    drawBbox(
+        0.dp,
+        0.dp,
+        Variables.cameraPreviewViewSize.width.dp,
+        100.dp,
+        result,
+        selectedDemo = UsecaseState.Barcode.value)
+    uiState.barcodeCountMap.clear()
 }
 
 @Composable


### PR DESCRIPTION
this feature is asked by Japan sales team, customer mentioned they want this kind of feature before,
they thought our OCR features can do this, but didn't find a good solution until they saw the AI Suite Demo on GTX.

I think for our AI Suite Demo app, showing the count for same EPC/EAN value barcodes also looks cool
and feature rich, it can inspire the SDK user too.

would you please consider merge this change into main branch ? Thank you !