### PR TITLE
Updated the naming of the apks to include version name to improve tracking of releases

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,7 @@ google-services.json
 
 # Android Profiling
 *.hprof
+AISuite_Demos/AI_Barcode_Finder/app/release/
+AISuite_Demos/AIDataCaptureDemo/app/release/
+AISuite_QuickStart/.kotlin/sessions/
+AISuite_QuickStart/app/release/

--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,4 @@ AISuite_Demos/AI_Barcode_Finder/app/release/
 AISuite_Demos/AIDataCaptureDemo/app/release/
 AISuite_QuickStart/.kotlin/sessions/
 AISuite_QuickStart/app/release/
+AISuite_Snippets/app/release/

--- a/AISuite_Demos/AIDataCaptureDemo/app/build.gradle.kts
+++ b/AISuite_Demos/AIDataCaptureDemo/app/build.gradle.kts
@@ -68,6 +68,18 @@ android {
             useLegacyPackaging = true
         }
     }
+
+    applicationVariants.all {
+        outputs.all {
+            val output = this as com.android.build.gradle.internal.api.BaseVariantOutputImpl
+            val versionName = defaultConfig.versionName
+            val versionCode = defaultConfig.versionCode
+            val buildType = buildType.name
+
+            // Format: AI_DataCapture_Demo-v1.8-release.apk or AI_DataCapture_Demo-v1.8-debug.apk
+            output.outputFileName = "AI_DataCapture_Demo-v${versionName}-${buildType}.apk"
+        }
+    }
 }
 
 dependencies {

--- a/AISuite_Demos/AI_Barcode_Finder/app/build.gradle.kts
+++ b/AISuite_Demos/AI_Barcode_Finder/app/build.gradle.kts
@@ -87,6 +87,18 @@ android {
     composeOptions {
         kotlinCompilerExtensionVersion = libs.versions.composeCompiler.get()
     }
+
+    applicationVariants.all {
+        outputs.all {
+            val output = this as com.android.build.gradle.internal.api.BaseVariantOutputImpl
+            val versionName = defaultConfig.versionName
+            val versionCode = defaultConfig.versionCode
+            val buildType = buildType.name
+
+            // Format: AI_Barcode_Finder-v1.8-release.apk or AI_Barcode_Finder-v1.8-debug.apk
+            output.outputFileName = "AI_Barcode_Finder-v${versionName}-${buildType}.apk"
+        }
+    }
 }
 
 dependencies {

--- a/AISuite_QuickStart/app/build.gradle.kts
+++ b/AISuite_QuickStart/app/build.gradle.kts
@@ -40,6 +40,18 @@ android {
     kotlinOptions {
         jvmTarget = "1.8"
     }
+
+    applicationVariants.all {
+        outputs.all {
+            val output = this as com.android.build.gradle.internal.api.BaseVariantOutputImpl
+            val versionName = defaultConfig.versionName
+            val versionCode = defaultConfig.versionCode
+            val buildType = buildType.name
+
+            // Format: AISuite_Quickstart-v1.8-release.apk or AISuite_Quickstart-v1.8-debug.apk
+            output.outputFileName = "AISuite_Quickstart-v${versionName}-${buildType}.apk"
+        }
+    }
 }
 
 dependencies {

--- a/AISuite_Snippets/app/build.gradle.kts
+++ b/AISuite_Snippets/app/build.gradle.kts
@@ -38,6 +38,18 @@ android {
     kotlinOptions {
         jvmTarget = "1.8"
     }
+
+    applicationVariants.all {
+        outputs.all {
+            val output = this as com.android.build.gradle.internal.api.BaseVariantOutputImpl
+            val versionName = defaultConfig.versionName
+            val versionCode = defaultConfig.versionCode
+            val buildType = buildType.name
+
+            // Format: AISuite_Snippets-v1.8-release.apk or AISuite_Snippets-v1.8-debug.apk
+            output.outputFileName = "AISuite_Snippets-v${versionName}-${buildType}.apk"
+        }
+    }
 }
 
 dependencies {


### PR DESCRIPTION
Improved the apk naming to include the version of the application.

APKs are now named with this structure:

"DemoName-v${versionName}-${buildType}.apk"